### PR TITLE
Feature/integrate everything in root files

### DIFF
--- a/examples/MassHierarchy/scripts/spectrum_analyzer.json
+++ b/examples/MassHierarchy/scripts/spectrum_analyzer.json
@@ -6,9 +6,9 @@
      "do_plots": True
    },
     "stan": {
-        
+
         "name": "spectrum_analyzer",
-        
+
         "model":   {
             "file": "./MassHierarchy/models/spectrum_analyzer.stan",
             "function_file": [
@@ -19,7 +19,7 @@
                               ],
             "cache": "./MassHierarchy/cache"
         },
-        
+
         "data": {
             "type": "mc",
             "files": [
@@ -28,8 +28,13 @@
                       "format":"R"
                       },
                       {
-                      "name": "./MassHierarchy/results/spectrum_additionalData.out",
-                      "format":"R"
+                      "name" : "./MassHierarchy/results/spectrum_generator_reduced_fake_NH.root",
+                      "format" : "root",
+                      "tree" : "additional_data",
+                      "branches" : [
+                                     {"name" : "nBinSpectrum", "stan_alias" : "nBinSpectrum", "data_format" : "integer"},
+                                     {"name" : "nBinTime", "stan_alias" : "nBinTime", "data_format" : "integer"},
+                                    ]
                       },
                       {
                       "name" : "./MassHierarchy/results/spectrum_generator_reduced_fake_NH.root",
@@ -49,23 +54,23 @@
                            }
                            ]
         },
-        
+
         "run": {
             "algorithm": "NUTS",
             "iter": 80000,
             "warmup" : 70000,
             "chain": 8},
-        
-        
+
+
         "sample": "./MassHierarchy/results/spectrum_analyzer.out",
-        
+
         "output":
         {
             "name" : "./MassHierarchy/results/spectrum_analyzer_NH3",
             "format": "root",
             "tree" : "analysis_parameters",
-            "save_cache_name": "./MassHierarchy/results/cache_fn/cache_name_file3.txt", 
-            "fit": "./MassHierarchy/results/analysis_fit_NH3.pkl", 
+            "save_cache_name": "./MassHierarchy/results/cache_fn/cache_name_file3.txt",
+            "fit": "./MassHierarchy/results/analysis_fit_NH3.pkl",
             "branches": [
                  {"variable": "Ue_squared", "root_alias": "Ue_squared", "ndim":3},
                  {"variable": "delta_m21","root_alias": "delta_m21"},
@@ -78,7 +83,7 @@
                  {"variable": "lp__","root_alias": "LogLikelihood"},
                      ]
         }
-        
+
     },
 
 "postprocessing":
@@ -103,7 +108,7 @@
         "data": {"Q":18574.95, "Ue_squared":"Ue_squared", "m_nu":"nu_mass", "time":3.0e+07, "activity":0.000032091, "bkgd_rate":0.000001, "x_axis_data":"KE_check", "x_label":"Kinetic Energy (eV)", "spectrum_data":"spectrum_rate_check"},
         "x_range": [18573.00, 18575.05],
         "y_scale": "log"
-        },   
+        },
         {
         "method_name": "neutrino_params",
         "module_name": "neutrino_params",

--- a/examples/MassHierarchy/scripts/spectrum_generator.json
+++ b/examples/MassHierarchy/scripts/spectrum_generator.json
@@ -8,9 +8,9 @@
    },
 
     "stan": {
-        
+
         "name": "spectrum_generator",
-        
+
         "model":   {
             "file": "./MassHierarchy/models/spectrum_generator.stan",
             "function_file": [
@@ -21,7 +21,7 @@
                               ],
             "cache": "./MassHierarchy/cache"
         },
-        
+
         "data": {
             "type": "mc",
             "files": [
@@ -40,15 +40,15 @@
                            ]
 
         },
-        
+
         "run": {
             "algorithm": "NUTS",
             "iter": 50000,
             "warmup": 25000,
             "chain": 10},
-        
+
         "sample": "./MassHierarchy/results/MHtest_generator.out",
-        
+
         "output":{
             "name": "./MassHierarchy/results/spectrum_generator_NH",
             "format": "root",
@@ -60,7 +60,7 @@
                     {"variable" : "spectrum_data", "root_alias": "spectrum_data"}
                      ]
         }
-        
+
     },
 
 "postprocessing":
@@ -81,7 +81,6 @@
         "output_file_format": "root",
         "output_KE_spectrum_tree": "spectrum",
         "output_time_spectrum_tree": "None",
-        "additional_file_name" : "./MassHierarchy/results/spectrum_additionalData.out",
       }
 
     ]

--- a/morpho/morpho.py
+++ b/morpho/morpho.py
@@ -124,6 +124,7 @@ class morpho(object):
             # STAN data
             datafiles = self.read_param(yd, 'stan.data', None)
             if datafiles is not None:
+                logger.debug("Loading datafiles")
                 self.data = pyL.stan_data_files(datafiles)
 
             # STAN run conditions

--- a/morpho/plot/histo.py
+++ b/morpho/plot/histo.py
@@ -60,7 +60,7 @@ def preparingCanvas(param_dict):
         height = 400
     return title, width, height
 
-def preparingTitles(paramdict):
+def preparingTitles(param_dict):
     # Setting the titles
     if 'x_title' in param_dict:
         xtitle = param_dict['x_title']
@@ -76,10 +76,13 @@ def preparingTitles(paramdict):
 def histo(param_dict):
 
     # Preparing the canvas
+    print("Preparing Canvas")
     title, width, height = preparingCanvas(param_dict)
     can = ROOT.TCanvas(title,title,width,height)
 
     # Setting the titles
+    print("Preparing Titles")
+
     xtitle, ytitle = preparingTitles(param_dict)
 
     gSave = []

--- a/morpho/postprocessing/data_reducer.py
+++ b/morpho/postprocessing/data_reducer.py
@@ -234,19 +234,19 @@ def data_reducer(param_dict):
     # canfakedata.SaveAs("tritium_model/ploting_scripts/" + "spectrum_vs_freq_data_average_logy.pdf")
 
     # Saving the additional data (aka the number of bin for each tree)
-    tuple = ROOT.TNtupleD("additional_data","additional_data","nBinSpectrum:nBinTime")
+    tuple = ROOT.TNtuple("additional_data","additional_data","nBinSpectrum:nBinTime")
     # f = open(param_dict['additional_file_name'],'w')
     if ('frequency' in param_dict['which_spectrum']):
-        value =(str(h.GetNbinsX()))
+        value =h.GetNbinsX()
     elif ('KE' in param_dict['which_spectrum']):
-        value =(str(he.GetNbinsX()))
-    s=str(value)
-    # f.write('nBinSpectrum <- ' + s + '\n')
+        value =he.GetNbinsX()
+
     if ('time' in param_dict['which_spectrum']):
-        value =(str(htime.GetNbinsX()))
-        s2=str(value)
-        # f.write('nBinTime <- ' + s2 + '\n')
-        tuple.Fill(s,s2)
+        value2 =htime.GetNbinsX()
+    else:
+        value2=0
+    tuple.Fill(value,value2)
+
     myfile.cd()
     tuple.Write()
     # f.close()

--- a/morpho/postprocessing/data_reducer.py
+++ b/morpho/postprocessing/data_reducer.py
@@ -234,19 +234,23 @@ def data_reducer(param_dict):
     # canfakedata.SaveAs("tritium_model/ploting_scripts/" + "spectrum_vs_freq_data_average_logy.pdf")
 
     # Saving the additional data (aka the number of bin for each tree)
-    f = open(param_dict['additional_file_name'],'w')
+    tuple = ROOT.TNtupleD("additional_data","additional_data","nBinSpectrum:nBinTime")
+    # f = open(param_dict['additional_file_name'],'w')
     if ('frequency' in param_dict['which_spectrum']):
         value =(str(h.GetNbinsX()))
     elif ('KE' in param_dict['which_spectrum']):
         value =(str(he.GetNbinsX()))
     s=str(value)
-    f.write('nBinSpectrum <- ' + s + '\n')
+    # f.write('nBinSpectrum <- ' + s + '\n')
     if ('time' in param_dict['which_spectrum']):
         value =(str(htime.GetNbinsX()))
-        s=str(value)
-        f.write('nBinTime <- ' + s + '\n')
-    f.close()
-
+        s2=str(value)
+        # f.write('nBinTime <- ' + s2 + '\n')
+    tuple.Fill(s,s2)
+    myfile.cd()
+    tuple.Write()
+    # f.close()
+    myfile.Close()
     print('Prostprocessing complete!')
 
 

--- a/morpho/postprocessing/data_reducer.py
+++ b/morpho/postprocessing/data_reducer.py
@@ -246,7 +246,7 @@ def data_reducer(param_dict):
         value =(str(htime.GetNbinsX()))
         s2=str(value)
         # f.write('nBinTime <- ' + s2 + '\n')
-    tuple.Fill(s,s2)
+        tuple.Fill(s,s2)
     myfile.cd()
     tuple.Write()
     # f.close()

--- a/morpho/pystanLoad.py
+++ b/morpho/pystanLoad.py
@@ -1,7 +1,7 @@
 # Definitions for loading and using pystan for analysis using root or hdf5
 
 import logging
-logger = logging.getLogger('pystanLoad.py')
+logger = logging.getLogger('morpho.py')
 logger.setLevel(logging.DEBUG)
 base_format = '%(asctime)s[%(levelname)-8s] %(name)s(%(lineno)d) -> %(message)s'
 logging.basicConfig(format=base_format, datefmt='%m/%d/%Y %H:%M:%S')
@@ -44,7 +44,6 @@ def theHack(theString,theVariable,theSecondVariable="",theThirdVariable=""):
 
 def stan_data_files(theData):
     alist = {}
-
     for tags in theData.keys():
         for key in theData[tags]:
             if tags=='files':
@@ -136,13 +135,13 @@ def stan_data_files(theData):
                                     insertIntoDataStruct(aname,areal[0], alist)
 
                                 else:
-                                    aint[0] = getattr(atree, lbr['name'])
+                                    aint[0] = int(getattr(atree, lbr['name']))
                                     insertIntoDataStruct(aname,aint[0], alist)
-
                             else:
                                 avalue = branch.GetValue(iEntry,1)
                                 insertIntoDataStruct(aname, avalue, alist)
-
+                        if len(alist[aname])==1:
+                            alist.update({aname: alist[aname][0]})
                     afile.Close()
 
                 else:
@@ -167,7 +166,6 @@ def write_result_hdf5(conf, ofilename, stanres):
                 """.format(stan_parname)
                 logger.debug(warning)
             else:
-                print(var['output_name'])
                 g[var['output_name']] = fit[stan_parname]
     logger.info('The file has been written to {}'.format(ofilename))
 


### PR DESCRIPTION
Solving issue https://github.com/project8/morpho/issues/8: we now save every informations about the reduced spectrum into the root file.
We still have the possibility of reading things into an additional_information.out file, but saving should be depreciated.
If really we need the feature back, we should add this as an option: if an additional file has to be created, a test checks if the corresponding field  is filled and creates the file according.
But the main info should be saved in the root file.