### PR TITLE
Feature/logger upgrade

### DIFF
--- a/bin/morpho
+++ b/bin/morpho
@@ -14,38 +14,12 @@ import os,sys
 reload(sys)
 sys.setdefaultencoding("utf-8")
 
-
-import logging
-logger = logging.getLogger('morpho')
-logger.propagate = False
-logger.setLevel(logging.DEBUG)
-logger.handlers = []
-
-base_format = '%(asctime)s{}[%(levelname)-8s] %(name)s(%(lineno)d) -> {}%(message)s'
-import colorlog
-fmt = colorlog.ColoredFormatter(
-        base_format.format('%(log_color)s', '%(purple)s'),
-        datefmt = '%Y-%m-%dT%H:%M:%SZ'[:-1],
-        reset=True,
-        )
-handler = logging.StreamHandler(sys.stdout)
-handler.setFormatter(fmt)
-logger.addHandler(handler)
-
 import time
 import re
 import random
 import ast
 
 import pystan
-
-logger_stan = logging.getLogger('pystan')
-logger_stan.propagate = False
-logger_stan.setLevel(logging.DEBUG)
-logger_stan.handlers = []
-handler_stan= logging.StreamHandler(sys.stdout)
-handler_stan.setFormatter(fmt)
-logger_stan.addHandler(handler_stan)
 
 from yaml import load as yload
 from argparse import ArgumentParser
@@ -54,6 +28,68 @@ from inspect import getargspec
 import pickle
 from hashlib import md5
 import importlib
+
+import logging
+import colorlog
+
+def get_logger_stderr(name, formatter, stderr_lb=logging.ERROR,
+                      level=logging.DEBUG, propagate=False):
+    """Return a logger object with the given settings that prints
+    messages greater than or equal to a given level to stderr instead of stdout
+    name: Name of the logger. Loggers are conceptually arranged
+          in a namespace hierarchy using periods as separators.
+          For example, a logger named morpho is the parent of a
+          logger named morpho.plot, and by default the child logger
+          will display messages with the same settings as the parent
+    formatter: A Formatter object used to format output
+    stderr_lb: Messages with level equal to or greaterthan stderr_lb
+               will be printed to stderr instead of stdout
+    level: Initial level for the logger
+    propagate: Whether messages to this logger should be passed to
+               the handlers of its ancestor"""
+
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    logger.propagate = propagate
+
+    class LessThanFilter(logging.Filter):
+        """Filter to get messages less than a given level
+        """
+        def __init__(self, exclusive_maximum, name=""):
+            super(LessThanFilter, self).__init__(name)
+            self.max_level = exclusive_maximum
+
+        def filter(self, record):
+            #non-zero return means we log this message
+            return 1 if record.levelno < self.max_level else 0
+
+    logger.handlers = []
+    handler_stdout = logging.StreamHandler(sys.stdout)
+    handler_stdout.setFormatter(formatter)
+    handler_stdout.setLevel(logging.DEBUG)
+    handler_stdout.addFilter(LessThanFilter(stderr_lb))
+    logger.addHandler(handler_stdout)
+    handler_stderr = logging.StreamHandler(sys.stderr)
+    handler_stderr.setFormatter(formatter)
+    handler_stderr.setLevel(stderr_lb)
+    logger.addHandler(handler_stderr)
+    return logger
+
+# Create morpho and pystan loggers
+# Will be reinstantiated after parsing command line args if __main__ is run
+base_format = '%(asctime)s{}[%(levelname)-8s] %(name)s(%(lineno)d) -> {}%(message)s'
+morpho_formatter = colorlog.ColoredFormatter(
+        base_format.format('%(log_color)s', '%(purple)s'),
+        datefmt = '%Y-%m-%dT%H:%M:%SZ'[:-1],
+        reset=True,
+        )
+propagate_morpho_loggers=False
+logger = get_logger_stderr('morpho', morpho_formatter,
+                           stderr_lb=logging.WARNING,
+                           propagate=propagate_morpho_loggers)
+logger_stan = get_logger_stderr('pystan', morpho_formatter,
+                                stderr_lb=logging.WARNING,
+                                propagate=propagate_morpho_loggers)
 
 class morpho(object):
     def read_param(self, yaml_data, node, default):
@@ -328,6 +364,16 @@ def parse_args():
                     default=False,
                     help='Do not save the Stan cache file',
                     required=False)
+    p.add_argument('-v', '--verbosity', default='DEBUG',
+                   metavar='<verbosity>',
+                   help="Specify verbosity of the logger, with options DEBUG, INFO, WARNING, ERROR, or CRITICAL (Default: DEBUG)",
+                   choices=['DEBUG','INFO','WARNING','ERROR','CRITICAL'],
+                   required=False)
+    p.add_argument('-sev', '--stderr-verbosity', default='WARNING',
+                   metavar='<stderr_verbosity>',
+                   help="Messages with level greater than or equal to the given verbosity will be redirected to stderr (Default: WARNING)",
+                   choices=['DEBUG','INFO','WARNING','ERROR','CRITICAL'],
+                   required=False)
     return p.parse_args()
 
 def update_from_arguments(the_dict,args):
@@ -542,6 +588,14 @@ DDDN?IIIIIIIIII7$$$$DDZ8    .N  7   8OZZZZZ$$$7III??IDD=\n\
                         |_|            ')
 
     args = parse_args()
+    logger = get_logger_stderr('morpho', morpho_formatter,
+                               level=getattr(logging,args.verbosity),
+                               stderr_lb=getattr(logging,args.stderr_verbosity),
+                               propagate=propagate_morpho_loggers)
+    logger_stan = get_logger_stderr('pystan', morpho_formatter,
+                               level=getattr(logging,args.verbosity),
+                               stderr_lb=getattr(logging,args.stderr_verbosity),
+                               propagate=propagate_morpho_loggers)
     with open(args.config, 'r') as cfile:
         try:
             cdata = yload(cfile)


### PR DESCRIPTION
The user can now input verbosity on the command line with -v DEBUG. (or INFO, WARNING, ERROR, CRITICAL). By default the verbosity is DEBUG, in order to maintain the previous behavior of morpho.

The same verbosity is used for the morpho logger, the loggers for all morpho modules, and the pystan loggers. (However, it seems that all  normal output of pystan, such as the current iteration, does not use a logger object. For this reason, changing the verbosity currently does not change pystan output.)

By default, messages with level WARNING or higher are sent to stderr instead of stdout. The user can change this via command line with -sev ERROR (etc).