### PR TITLE
Prevent crashing when reading an rdump formatted file with empty lines

### DIFF
--- a/morpho/loader/pystanLoad.py
+++ b/morpho/loader/pystanLoad.py
@@ -182,12 +182,14 @@ def _save_repeated_as_arr(rdump_filename, data_dict=dict()):
     var_1d = [] # Will be true if all inputs are a single value
     for line in open(rdump_filename, 'r'):
         splitline = map(str.strip,line.split("<-"))
+        if(len(splitline)<2):
+            continue
         name = splitline[0]
         data = splitline[1]
         # Ignore data that is not a 1d array or numeric
         if(('0'<=data[0] and data[0]<='9') or data[0]=='.'
-           or data[0:2]=='c('):
-            if(data[0:2]=='c('):
+           or data[0]=='c'):
+            if(data[0]=='c'):
                 data = list(map(float,data[2:-1].split(',')))
                 array = True
             elif('.' in data):


### PR DESCRIPTION
Commit 8d55839 allowed users to input rdump data by row, but
introduced a bug that caused morpho to crash if an rdump file
had an empty line. This code checks that each line exists
before trying to access it.